### PR TITLE
Reduce Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,14 +1544,12 @@ name = "piicleaner"
 version = "0.4.0"
 dependencies = [
  "criterion",
- "once_cell",
  "polars",
  "pyo3",
  "pyo3-build-config",
  "pyo3-polars",
  "rayon",
  "regex",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piicleaner"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ pyo3 = { version = "0.24.2", features = ["extension-module"] }
 pyo3-polars = { version = "0.21.0", features = ["derive"] }
 rayon = "1.10"
 regex = "1.11"
-serde = { version = "1.0", features = ["derive"] }
-once_cell = "1.21"
 
 [build-dependencies]
 pyo3-build-config = "0.24"

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ test:  ## Run tests (no performance)
 	cargo test
 	uv run pytest -v -m "not performance"
 
+# Performance tests take c. 4-5 mins to run
 test_performance: ## Run performance and benchmarking tests
 	cargo test --release -- --ignored
 	uv run pytest -v -m "performance"

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -1,8 +1,8 @@
 //! PII regex patterns
 
-use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder, RegexSet, RegexSetBuilder};
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 pub struct PatternRegistry {
     patterns: HashMap<&'static str, Vec<&'static str>>,
@@ -94,47 +94,49 @@ pub fn get_patterns_by_name(cleaners: &[&str]) -> Vec<&'static str> {
     get_registry().get_patterns_by_name(cleaners)
 }
 
-pub static PATTERNS_COMPILED_CASE_SENSITIVE: Lazy<HashMap<&str, Vec<Regex>>> = Lazy::new(|| {
-    let registry = get_registry();
-    let mut map = HashMap::new();
+pub static PATTERNS_COMPILED_CASE_SENSITIVE: LazyLock<HashMap<&str, Vec<Regex>>> =
+    LazyLock::new(|| {
+        let registry = get_registry();
+        let mut map = HashMap::new();
 
-    for cleaner_name in registry.get_available_cleaners() {
-        let patterns = registry.get_patterns_by_name(&[cleaner_name]);
-        let compiled: Vec<Regex> = patterns
-            .into_iter()
-            .map(|p| Regex::new(p).expect("Invalid regex"))
-            .collect();
-        map.insert(cleaner_name, compiled);
-    }
-    map
-});
+        for cleaner_name in registry.get_available_cleaners() {
+            let patterns = registry.get_patterns_by_name(&[cleaner_name]);
+            let compiled: Vec<Regex> = patterns
+                .into_iter()
+                .map(|p| Regex::new(p).expect("Invalid regex"))
+                .collect();
+            map.insert(cleaner_name, compiled);
+        }
+        map
+    });
 
-pub static PATTERNS_COMPILED_CASE_INSENSITIVE: Lazy<HashMap<&str, Vec<Regex>>> = Lazy::new(|| {
-    let registry = get_registry();
-    let mut map = HashMap::new();
+pub static PATTERNS_COMPILED_CASE_INSENSITIVE: LazyLock<HashMap<&str, Vec<Regex>>> =
+    LazyLock::new(|| {
+        let registry = get_registry();
+        let mut map = HashMap::new();
 
-    for cleaner_name in registry.get_available_cleaners() {
-        let patterns = registry.get_patterns_by_name(&[cleaner_name]);
-        let compiled: Vec<Regex> = patterns
-            .into_iter()
-            .map(|p| {
-                RegexBuilder::new(p)
-                    .case_insensitive(true)
-                    .build()
-                    .expect("Invalid regex")
-            })
-            .collect();
-        map.insert(cleaner_name, compiled);
-    }
-    map
-});
+        for cleaner_name in registry.get_available_cleaners() {
+            let patterns = registry.get_patterns_by_name(&[cleaner_name]);
+            let compiled: Vec<Regex> = patterns
+                .into_iter()
+                .map(|p| {
+                    RegexBuilder::new(p)
+                        .case_insensitive(true)
+                        .build()
+                        .expect("Invalid regex")
+                })
+                .collect();
+            map.insert(cleaner_name, compiled);
+        }
+        map
+    });
 
-pub static PATTERNS_SET_CASE_SENSITIVE: Lazy<RegexSet> = Lazy::new(|| {
+pub static PATTERNS_SET_CASE_SENSITIVE: LazyLock<RegexSet> = LazyLock::new(|| {
     let pattern_strings = get_all_patterns();
     RegexSet::new(pattern_strings).expect("Failed to create regex set")
 });
 
-pub static PATTERNS_SET_CASE_INSENSITIVE: Lazy<RegexSet> = Lazy::new(|| {
+pub static PATTERNS_SET_CASE_INSENSITIVE: LazyLock<RegexSet> = LazyLock::new(|| {
     let pattern_strings = get_all_patterns();
     RegexSetBuilder::new(pattern_strings)
         .case_insensitive(true)
@@ -143,7 +145,7 @@ pub static PATTERNS_SET_CASE_INSENSITIVE: Lazy<RegexSet> = Lazy::new(|| {
 });
 
 /// Pre-computed replacement strings for semantic redaction
-pub static REPLACEMENT_STRINGS: Lazy<HashMap<&str, String>> = Lazy::new(|| {
+pub static REPLACEMENT_STRINGS: LazyLock<HashMap<&str, String>> = LazyLock::new(|| {
     let registry = get_registry();
     let mut map = HashMap::new();
 


### PR DESCRIPTION
## Summary
- Remove unused `once_cell` and `serde` dependencies from Cargo.toml
- Replace `once_cell::sync::Lazy` with `std::sync::LazyLock` throughout patterns.rs
- Reduces total dependency count while maintaining identical functionality

## Test plan
- [x] All Rust tests pass
- [x] All Python tests pass  
- [x] Performance benchmarks run successfully
- [x] Code formatted by pre-commit hooks

Closes #13